### PR TITLE
Upgrade SCI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                   [org.clojure/clojure "1.10.3"]
                   [org.clojure/tools.cli "1.0.194"]
                   [org.clojure/core.async "1.3.618"]
-                  [borkdude/sci "0.2.6"]
+                  [org.babashka/sci "0.3.2"]
                   [byte-streams "0.2.4"]
                   [http-kit "2.5.3"]
                   [ring "1.9.3"]


### PR DESCRIPTION
SCI has moved to a new organization: `org.babashka/sci {:mvn/version "0.3.2"}`.

Having both `borkdude/sci` and `org.babashka/sci` on the classpath can cause problems.